### PR TITLE
Splitting externals into a separated file

### DIFF
--- a/examples/ga-feature.html
+++ b/examples/ga-feature.html
@@ -50,6 +50,7 @@
     </div>
     <script src="http://geoadmin.github.io/ol3/proj4js-compressed.js"></script> 
     <script src="http://geoadmin.github.io/ol3/EPSG21781.js"></script> 
+    <script src="../build/serverconfig.js" type="text/javascript"></script> 
     <script src="../build/layersconfig.en.js" type="text/javascript"></script> 
     <script src="loader.js?id=ga-feature" type="text/javascript"></script>
 

--- a/examples/ga-geocode.html
+++ b/examples/ga-geocode.html
@@ -50,6 +50,7 @@
     </div>
     <script src="http://geoadmin.github.io/ol3/proj4js-compressed.js"></script> 
     <script src="http://geoadmin.github.io/ol3/EPSG21781.js"></script> 
+    <script src="../build/serverconfig.js" type="text/javascript"></script> 
     <script src="../build/layersconfig.en.js" type="text/javascript"></script> 
     <script src="loader.js?id=ga-geocode" type="text/javascript"></script>
   </body>

--- a/examples/ga-side-by-side.html
+++ b/examples/ga-side-by-side.html
@@ -57,6 +57,7 @@
 
     <script src="http://geoadmin.github.io/ol3/proj4js-compressed.js"></script> 
     <script src="http://geoadmin.github.io/ol3/EPSG21781.js"></script> 
+    <script src="../build/serverconfig.js" type="text/javascript"></script> 
     <script src="../build/layersconfig.de.js" type="text/javascript"></script> 
     <script src="loader.js?id=ga-side-by-side" type="text/javascript"></script>
 

--- a/examples/ga-simple.html
+++ b/examples/ga-simple.html
@@ -48,6 +48,7 @@
       </div>
 
     </div>
+    <script src="../build/serverconfig.js" type="text/javascript"></script> 
     <script src="http://geoadmin.github.io/ol3/proj4js-compressed.js"></script> 
     <script src="http://geoadmin.github.io/ol3/EPSG21781.js"></script> 
     <script src="../build/layersconfig.de.js" type="text/javascript"></script> 

--- a/examples/ga-static-build.html
+++ b/examples/ga-static-build.html
@@ -49,6 +49,7 @@
 
     </div>
     <script src="../build/layersconfig.de.js" type="text/javascript"></script> 
+    <script src="../build/layersconfig.de.js" type="text/javascript"></script> 
     <script src="../build/ga.js" type="text/javascript"></script>
     <script src="ga-static-build.combined.js" type="text/javascript"></script>
 

--- a/examples/ga-static-whitespace.html
+++ b/examples/ga-static-whitespace.html
@@ -48,6 +48,7 @@
       </div>
 
     </div>
+    <script src="../build/serverconfig.js" type="text/javascript"></script> 
     <script src="../build/layersconfig.de.js" type="text/javascript"></script> 
     <script src="../build/ga-whitespace.js" type="text/javascript"></script>
     <script src="ga-static-whitespace.combined.js" type="text/javascript"></script>

--- a/examples/ga-vector-layer.html
+++ b/examples/ga-vector-layer.html
@@ -47,6 +47,7 @@
       </div>
 
     </div>
+    <script src="../build/serverconfig.js" type="text/javascript"></script> 
     <script src="../build/layersconfig.de.js" type="text/javascript"></script>
     <script src="http://cdnjs.cloudflare.com/ajax/libs/proj4js/1.1.0/proj4js-compressed.js" type="text/javascript"></script>
     <script src="http://cdnjs.cloudflare.com/ajax/libs/proj4js/1.1.0/defs/EPSG21781.js" type="text/javascript"></script>


### PR DESCRIPTION
In the examples, you may choose to load the `serverconfig.js` or not, but you _have_ to define somewhere the externals...
