### PR TITLE
Add needed slash after serviceUrl

### DIFF
--- a/src/ga/map.js
+++ b/src/ga/map.js
@@ -147,7 +147,7 @@ ga.Map.prototype.handleGeocodeError_ = function(response) {
  */
 ga.Map.prototype.recenterFeature = function(layerId, featureId) {
   var jsonp = new goog.net.Jsonp(
-    this.serviceUrl + 'rest/services/api/MapServer/' +
+    this.serviceUrl + '/rest/services/api/MapServer/' +
     layerId + '/' + featureId);
   var payload = { 'geometryFormat': 'geojson' };
   jsonp.send(payload, 
@@ -179,7 +179,7 @@ ga.Map.prototype.recenterToFeature_ = function(feature) {
  */
 ga.Map.prototype.highlightFeature = function(layerId, featureId) {
   var jsonp = new goog.net.Jsonp(
-    this.serviceUrl + 'rest/services/api/MapServer/' +
+    this.serviceUrl + '/rest/services/api/MapServer/' +
     layerId + '/' + featureId);
   var payload = { 'geometryFormat': 'geojson' };
   jsonp.send(payload, 


### PR DESCRIPTION
Here's the fix.

Fixes issue discussed here: https://github.com/geoadmin/mf-geoadmin3/issues/1232
