### PR TITLE
Use waf-less adresses

### DIFF
--- a/src/ga/layer/layer.js
+++ b/src/ga/layer/layer.js
@@ -167,7 +167,7 @@ ga.source.wmts = function(layer, options) {
         '" target="new">' +
         options['attribution'] + '</a>')
     ],
-    url: ('http://wmts{0-4}.geo.admin.ch/1.0.0/{Layer}/default/'+
+    url: ('http://wmts{5-9}.geo.admin.ch/1.0.0/{Layer}/default/'+
         timestamp + '/21781/' +
         '{TileMatrix}/{TileRow}/{TileCol}.').replace('http:',location.protocol) + extension,
     tileGrid: tileGrid,


### PR DESCRIPTION
Same adaption for API as for map geoadmin: see https://github.com/geoadmin/mf-geoadmin3/pull/1457/files
