### PR TITLE
Remove useless anchor

### DIFF
--- a/src/ga/tooltip.js
+++ b/src/ga/tooltip.js
@@ -96,7 +96,6 @@ ga.Tooltip.prototype.createOverlay_ = function() {
   goog.events.listen(this.tooltipContentElement_ , 'mousewheel',
       this.handleWheel_, false, this);
   var closeAnchor = goog.dom.createDom(goog.dom.TagName.A, {
-    'href': '#',
     'class': className + '-closer'
   });
   goog.events.listen(closeAnchor, 'click',


### PR DESCRIPTION
Because it makes the page scroll up when one closes the tooltip.
I don't think this is wanted and some customers are complaining about it.